### PR TITLE
feat(m3): Agente de Onboarding — cadastro de clientes via WhatsApp

### DIFF
--- a/agents/onboarding/graph.py
+++ b/agents/onboarding/graph.py
@@ -1,0 +1,109 @@
+"""
+Grafo LangGraph do Agente de Onboarding.
+
+Fluxo push (corretor inicia com /cadastrar):
+  entry_router → contact_client → collect_client (multi-turn) → collect_policy (multi-turn)
+               → confirm → handle_confirmation → register → welcome → notify_seller → END
+
+Fluxo pull (cliente chega sem cadastro):
+  entry_router → collect_client (multi-turn) → collect_policy (multi-turn)
+               → confirm → handle_confirmation → register → welcome → notify_seller → END
+
+Falha após max retries:
+  register → escalate → END
+
+Cancelamento:
+  cancel_onboarding → END
+
+O estado persiste em Redis entre acionamentos do webhook.
+"""
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from agents.onboarding.nodes import (
+    cancel_onboarding_node,
+    collect_client_node,
+    collect_policy_node,
+    confirm_node,
+    contact_client_node,
+    entry_router_node,
+    escalate_node,
+    handle_confirmation_node,
+    notify_seller_node,
+    register_node,
+    route_after_register,
+    route_client_collection,
+    route_confirmation,
+    route_entry,
+    route_policy_collection,
+    welcome_node,
+)
+from agents.onboarding.state import OnboardingState
+
+
+def build_onboarding_graph() -> CompiledStateGraph:
+    graph = StateGraph(OnboardingState)
+
+    graph.add_node("entry_router",        entry_router_node)
+    graph.add_node("contact_client",      contact_client_node)
+    graph.add_node("collect_client",      collect_client_node)
+    graph.add_node("collect_policy",      collect_policy_node)
+    graph.add_node("confirm",             confirm_node)
+    graph.add_node("handle_confirmation", handle_confirmation_node)
+    graph.add_node("register",            register_node)
+    graph.add_node("welcome",             welcome_node)
+    graph.add_node("notify_seller",       notify_seller_node)
+    graph.add_node("escalate",            escalate_node)
+    graph.add_node("cancel_onboarding",   cancel_onboarding_node)
+
+    graph.set_entry_point("entry_router")
+
+    # Roteamento de entrada pelo status atual
+    graph.add_conditional_edges("entry_router", route_entry, {
+        "contact_client":      "contact_client",
+        "collect_client":      "collect_client",
+        "collect_policy":      "collect_policy",
+        "handle_confirmation": "handle_confirmation",
+        "cancel":              "cancel_onboarding",
+        "end":                 END,
+    })
+
+    # Após contato proativo (push): coleta dados do cliente
+    graph.add_edge("contact_client", END)  # aguarda resposta do cliente
+
+    # collect_client: continua quando todos os dados pessoais estão completos
+    graph.add_conditional_edges("collect_client", route_client_collection, {
+        "complete":   "collect_policy",
+        "incomplete": END,  # aguarda próxima mensagem
+    })
+
+    # collect_policy: continua quando todos os dados da apólice estão completos
+    graph.add_conditional_edges("collect_policy", route_policy_collection, {
+        "complete":   "confirm",
+        "incomplete": END,  # aguarda próxima mensagem
+    })
+
+    # confirm: envia resumo e aguarda confirmação
+    graph.add_edge("confirm", END)  # aguarda "sim" ou "não" do cliente
+
+    # handle_confirmation: processa a resposta de confirmação
+    graph.add_conditional_edges("handle_confirmation", route_confirmation, {
+        "confirmed": "register",
+        "rejected":  END,   # volta para coleta após reset do estado
+        "unclear":   END,   # pede esclarecimento
+    })
+
+    # register: cria cliente e apólice no banco
+    graph.add_conditional_edges("register", route_after_register, {
+        "welcome":  "welcome",
+        "escalate": "escalate",
+    })
+
+    # welcome → notify_seller → END (fluxo de sucesso)
+    graph.add_edge("welcome",       "notify_seller")
+    graph.add_edge("notify_seller", END)
+
+    graph.add_edge("escalate",        END)
+    graph.add_edge("cancel_onboarding", END)
+
+    return graph.compile()

--- a/agents/onboarding/nodes.py
+++ b/agents/onboarding/nodes.py
@@ -324,17 +324,15 @@ async def handle_confirmation_node(state: dict) -> dict:
     user_messages = [m for m in messages if m.get("role") == "user"]
     latest = user_messages[-1].get("content", "").lower().strip() if user_messages else ""
 
-    confirmed_words = {
-        "sim", "s", "confirmo", "pode", "ok", "certo", "isso", "correto", "tudo certo", "cadastra",
-    }
-    rejected_words = {  # noqa: E501
-        "não", "nao", "n", "errado", "errada", "corrigir", "mudar", "alterar", "refazer",
-    }
+    # Palavras inteiras para evitar falsos positivos de substring (ex: "n" em "nenhum")
+    words = set(latest.split())
+    confirmed_words = {"sim", "confirmo", "pode", "ok", "certo", "isso", "correto", "cadastra"}
+    rejected_words = {"não", "nao", "errado", "errada", "corrigir", "mudar", "alterar", "refazer"}
 
-    if any(w in latest for w in confirmed_words):
+    if words & confirmed_words or "tudo certo" in latest:
         return {"confirmation_status": "confirmed"}
 
-    if any(w in latest for w in rejected_words):
+    if words & rejected_words:
         msg = "Tudo bem! Vamos recomeçar a coleta. Pode me confirmar seu nome completo?"
         await notification_service.send_whatsapp_message(client_phone, msg)
         return {
@@ -367,66 +365,63 @@ def route_confirmation(state: dict) -> str:
 async def register_node(state: dict) -> dict:
     """
     Cria o cliente e a apólice no banco de dados.
-    Em caso de falha: incrementa retry_count. Se >= _MAX_RETRIES, escala para corretor.
+    Tenta até _MAX_RETRIES vezes internamente antes de sinalizar falha.
     """
     client_phone = state.get("client_phone", "")
     client_data = state.get("client_data", {})
     policy_data = state.get("policy_data", {})
-    retry_count = state.get("retry_count", 0)
 
-    try:
-        # Cria / busca seguradora
-        insurer_id = await get_or_create_insurer(policy_data.get("insurer", "Não informada"))
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            # Cria / busca seguradora
+            insurer_id = await get_or_create_insurer(policy_data.get("insurer", "Não informada"))
 
-        # Cria cliente (retorna existente se CPF já cadastrado)
-        client_id = await create_client(
-            full_name=client_data.get("full_name", ""),
-            cpf_cnpj=client_data.get("cpf", ""),
-            phone_whatsapp=client_phone,
-            email=client_data.get("email"),
-        )
+            # Cria cliente (retorna existente se CPF já cadastrado)
+            client_id = await create_client(
+                full_name=client_data.get("full_name", ""),
+                cpf_cnpj=client_data.get("cpf", ""),
+                phone_whatsapp=client_phone,
+                email=client_data.get("email"),
+            )
 
-        # Cria apólice
-        policy_id = await create_policy(
-            client_id=client_id,
-            insurer_id=insurer_id,
-            policy_number=policy_data.get("policy_number", ""),
-            policy_type=policy_data.get("policy_type", "auto"),
-            item_description=policy_data.get("item_description", ""),
-            end_date=policy_data.get("end_date", ""),
-            start_date=policy_data.get("start_date"),
-            seller_phone=settings.broker_notification_phone,
-        )
+            # Cria apólice
+            policy_id = await create_policy(
+                client_id=client_id,
+                insurer_id=insurer_id,
+                policy_number=policy_data.get("policy_number", ""),
+                policy_type=policy_data.get("policy_type", "auto"),
+                item_description=policy_data.get("item_description", ""),
+                end_date=policy_data.get("end_date", ""),
+                start_date=policy_data.get("start_date"),
+                seller_phone=settings.broker_notification_phone,
+            )
 
-        logger.info(
-            "Onboarding concluído: client_id=%s policy_id=%s phone=%s",
-            client_id, policy_id, client_phone,
-        )
-        return {
-            "client_id": client_id,
-            "policy_id": policy_id,
-            "registered": True,
-            "status": "registered",
-        }
-
-    except Exception as exc:
-        logger.error("Erro ao registrar cliente/apólice para %s: %s", client_phone, exc)
-        new_retry = retry_count + 1
-        if new_retry >= _MAX_RETRIES:
+            logger.info(
+                "Onboarding concluído: client_id=%s policy_id=%s phone=%s",
+                client_id, policy_id, client_phone,
+            )
             return {
-                "retry_count": new_retry,
-                "failed": True,
-                "status": "failed",
+                "client_id": client_id,
+                "policy_id": policy_id,
+                "registered": True,
+                "status": "registered",
             }
-        return {"retry_count": new_retry}
+
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "Tentativa %d/%d falhou para %s: %s", attempt + 1, _MAX_RETRIES, client_phone, exc
+            )
+
+    logger.error("Todas as tentativas falharam para %s: %s", client_phone, last_exc)
+    return {"failed": True, "status": "failed"}
 
 
 def route_after_register(state: dict) -> str:
-    if state.get("failed"):
-        return "escalate"
     if state.get("registered"):
         return "welcome"
-    return "escalate"  # fallback
+    return "escalate"
 
 
 # ---------------------------------------------------------------------------

--- a/agents/onboarding/nodes.py
+++ b/agents/onboarding/nodes.py
@@ -236,10 +236,9 @@ async def collect_policy_node(state: dict) -> dict:
         "start_date": extracted.get("start_date") or prev.get("start_date"),
     }
 
-    missing = list(extracted.get("missing_fields", []))
     error_context = ""
 
-    # Recalcula missing com base no estado consolidado
+    # Recalcula missing com base nos campos obrigatórios
     required = ["insurer", "item_description", "policy_number", "end_date"]
     missing = [f for f in required if not policy_data.get(f)]
 

--- a/agents/onboarding/nodes.py
+++ b/agents/onboarding/nodes.py
@@ -1,0 +1,498 @@
+"""
+Nós do grafo do Agente de Onboarding.
+Cada nó recebe OnboardingState e retorna um dict com os campos atualizados.
+
+Fluxo:
+  entry_router → contact_client (push) | collect_client (pull/retomada)
+               → collect_policy → confirm → handle_confirmation
+               → register → welcome → notify_seller → END
+"""
+import json
+import logging
+from datetime import UTC, datetime
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from agents.llm import get_llm as _get_llm_factory
+from agents.onboarding.prompts import (
+    BROKER_ESCALATION_ALERT,
+    BROKER_NOTIFICATION,
+    CANCEL_MESSAGE,
+    CONFIRMATION_MESSAGE,
+    ESCALATION_MESSAGE,
+    EXTRACT_CLIENT_DATA_PROMPT,
+    EXTRACT_POLICY_DATA_PROMPT,
+    GENERATE_CLIENT_QUESTION_PROMPT,
+    GENERATE_POLICY_QUESTION_PROMPT,
+    ONBOARDING_SYSTEM_PROMPT,
+    WELCOME_MESSAGE,
+)
+from models.config import settings
+from services import notification_service
+from services.onboarding_service import (
+    create_client,
+    create_policy,
+    get_or_create_insurer,
+    validate_cpf,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+
+
+def _get_llm():
+    return _get_llm_factory(max_tokens=1024)
+
+
+def _messages_to_text(messages: list[dict]) -> str:
+    recent = messages[-20:]
+    lines = []
+    for m in recent:
+        role = "Cliente" if m.get("role") == "user" else "Assistente"
+        lines.append(f"{role}: {m.get('content', '')}")
+    return "\n".join(lines)
+
+
+def _parse_json_response(text: str) -> dict:
+    """Extrai JSON de uma resposta do LLM (tolera texto antes/depois do JSON)."""
+    try:
+        start = text.index("{")
+        end = text.rindex("}") + 1
+        return json.loads(text[start:end])
+    except (ValueError, json.JSONDecodeError):
+        logger.warning("Falha ao parsear JSON da resposta LLM: %s", text[:200])
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Roteamento de entrada
+# ---------------------------------------------------------------------------
+
+def entry_router_node(state: dict) -> dict:
+    """Nó de entrada — não altera estado. Roteamento via conditional edges."""
+    return {}
+
+
+def route_entry(state: dict) -> str:
+    status = state.get("status", "")
+    push_mode = state.get("push_mode", False)
+
+    if status in ("registered", "failed"):
+        return "end"
+    if status == "cancel":
+        return "cancel"
+    if status == "awaiting_confirmation":
+        return "handle_confirmation"
+    if status == "collecting_policy":
+        return "collect_policy"
+    if push_mode and not status:
+        return "contact_client"
+    return "collect_client"
+
+
+# ---------------------------------------------------------------------------
+# Contato proativo (modo push)
+# ---------------------------------------------------------------------------
+
+async def contact_client_node(state: dict) -> dict:
+    """
+    Modo push: envia mensagem proativa ao cliente e pede o nome para iniciar.
+    Executado apenas uma vez, no primeiro acionamento via /cadastrar.
+    """
+    phone = state.get("client_phone", "")
+    greeting = (
+        "Olá! Sou o assistente da corretora. O seu corretor pediu pra eu "
+        "fazer seu cadastro rapidinho aqui no WhatsApp. 😊\n\n"
+        "Pode me confirmar seu nome completo para começarmos?"
+    )
+    await notification_service.send_whatsapp_message(phone, greeting)
+    return {
+        "messages": [{"role": "assistant", "content": greeting}],
+        "status": "collecting_client",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coleta de dados do cliente (multi-turn)
+# ---------------------------------------------------------------------------
+
+async def collect_client_node(state: dict) -> dict:
+    """
+    Extrai nome e CPF do cliente das mensagens da conversa.
+    - Valida CPF via algoritmo de dígito verificador.
+    - Se incompleto: gera pergunta, envia ao cliente e retorna (aguarda próxima msg).
+    - Se completo e válido: marca client_data_complete=True para prosseguir.
+    """
+    llm = _get_llm()
+    messages = state.get("messages", [])
+    client_phone = state.get("client_phone", "")
+
+    messages_text = _messages_to_text(messages)
+
+    # Primeira interação em modo pull — sem mensagem anterior do assistente
+    has_prior_assistant = any(m.get("role") == "assistant" for m in messages)
+    first_contact_hint = (
+        "Esta é a primeira mensagem do cliente. Comece com uma saudação amigável."
+        if not has_prior_assistant else ""
+    )
+
+    # Extrai dados já fornecidos
+    extract_prompt = EXTRACT_CLIENT_DATA_PROMPT.format(messages=messages_text)
+    response = await llm.ainvoke([
+        SystemMessage(content=ONBOARDING_SYSTEM_PROMPT),
+        HumanMessage(content=extract_prompt),
+    ])
+    extracted = _parse_json_response(response.content)
+
+    prev = state.get("client_data", {})
+    client_data = {
+        "full_name": extracted.get("full_name") or prev.get("full_name"),
+        "cpf": extracted.get("cpf") or prev.get("cpf"),
+        "email": extracted.get("email") or prev.get("email"),
+    }
+
+    missing = list(extracted.get("missing_fields", []))
+    error_context = first_contact_hint
+
+    # Valida CPF se presente
+    cpf = client_data.get("cpf") or ""
+    if cpf and not validate_cpf(cpf):
+        client_data["cpf"] = None
+        if "cpf" not in missing:
+            missing.append("cpf")
+        error_context = (
+            "O CPF informado parece inválido. "
+            "Peça que o cliente confira e informe novamente."
+        )
+
+    # Recalcula campos faltantes com base no estado consolidado
+    missing = [f for f in missing if not client_data.get(f)]
+
+    if not missing:
+        return {
+            "client_data": client_data,
+            "client_data_complete": True,
+        }
+
+    # Gera pergunta para o campo faltante
+    question_prompt = GENERATE_CLIENT_QUESTION_PROMPT.format(
+        missing_fields=", ".join(missing),
+        messages=messages_text,
+        error_context=error_context,
+    )
+    q_response = await llm.ainvoke([
+        SystemMessage(content=ONBOARDING_SYSTEM_PROMPT),
+        HumanMessage(content=question_prompt),
+    ])
+    question = q_response.content.strip()
+
+    await notification_service.send_whatsapp_message(client_phone, question)
+    updated_messages = messages + [{"role": "assistant", "content": question}]
+
+    return {
+        "client_data": client_data,
+        "client_data_complete": False,
+        "messages": updated_messages,
+        "status": "collecting_client",
+    }
+
+
+def route_client_collection(state: dict) -> str:
+    return "complete" if state.get("client_data_complete") else "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Coleta de dados da apólice (multi-turn)
+# ---------------------------------------------------------------------------
+
+async def collect_policy_node(state: dict) -> dict:
+    """
+    Extrai dados da apólice das mensagens da conversa.
+    - Campos obrigatórios: insurer, item_description, policy_number, end_date.
+    - Se incompleto: gera pergunta e aguarda próxima mensagem.
+    - Se completo: marca policy_data_complete=True para prosseguir.
+    """
+    llm = _get_llm()
+    messages = state.get("messages", [])
+    client_phone = state.get("client_phone", "")
+
+    messages_text = _messages_to_text(messages)
+
+    extract_prompt = EXTRACT_POLICY_DATA_PROMPT.format(messages=messages_text)
+    response = await llm.ainvoke([
+        SystemMessage(content=ONBOARDING_SYSTEM_PROMPT),
+        HumanMessage(content=extract_prompt),
+    ])
+    extracted = _parse_json_response(response.content)
+
+    prev = state.get("policy_data", {})
+    policy_data = {
+        "insurer": extracted.get("insurer") or prev.get("insurer"),
+        "policy_type": extracted.get("policy_type") or prev.get("policy_type") or "auto",
+        "item_description": extracted.get("item_description") or prev.get("item_description"),
+        "policy_number": extracted.get("policy_number") or prev.get("policy_number"),
+        "end_date": extracted.get("end_date") or prev.get("end_date"),
+        "start_date": extracted.get("start_date") or prev.get("start_date"),
+    }
+
+    missing = list(extracted.get("missing_fields", []))
+    error_context = ""
+
+    # Recalcula missing com base no estado consolidado
+    required = ["insurer", "item_description", "policy_number", "end_date"]
+    missing = [f for f in required if not policy_data.get(f)]
+
+    if not missing:
+        return {
+            "policy_data": policy_data,
+            "policy_data_complete": True,
+        }
+
+    # Se é a primeira pergunta sobre apólice, dar contexto de transição
+    has_policy_question = any(
+        "apólice" in m.get("content", "").lower() or
+        "seguradora" in m.get("content", "").lower()
+        for m in messages if m.get("role") == "assistant"
+    )
+    if not has_policy_question:
+        error_context = "Dados pessoais já coletados. Agora colete os dados da apólice de seguro."
+
+    question_prompt = GENERATE_POLICY_QUESTION_PROMPT.format(
+        missing_fields=", ".join(missing),
+        messages=messages_text,
+        error_context=error_context,
+    )
+    q_response = await llm.ainvoke([
+        SystemMessage(content=ONBOARDING_SYSTEM_PROMPT),
+        HumanMessage(content=question_prompt),
+    ])
+    question = q_response.content.strip()
+
+    await notification_service.send_whatsapp_message(client_phone, question)
+    updated_messages = messages + [{"role": "assistant", "content": question}]
+
+    return {
+        "policy_data": policy_data,
+        "policy_data_complete": False,
+        "messages": updated_messages,
+        "status": "collecting_policy",
+    }
+
+
+def route_policy_collection(state: dict) -> str:
+    return "complete" if state.get("policy_data_complete") else "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Confirmação dos dados
+# ---------------------------------------------------------------------------
+
+async def confirm_node(state: dict) -> dict:
+    """Envia resumo dos dados coletados e pede confirmação do cliente."""
+    client_phone = state.get("client_phone", "")
+    client_data = state.get("client_data", {})
+    policy_data = state.get("policy_data", {})
+
+    msg = CONFIRMATION_MESSAGE.format(
+        full_name=client_data.get("full_name", ""),
+        cpf=client_data.get("cpf", ""),
+        insurer=policy_data.get("insurer", ""),
+        policy_number=policy_data.get("policy_number", ""),
+        item_description=policy_data.get("item_description", ""),
+        end_date=policy_data.get("end_date", ""),
+    )
+    await notification_service.send_whatsapp_message(client_phone, msg)
+
+    messages = state.get("messages", [])
+    return {
+        "messages": messages + [{"role": "assistant", "content": msg}],
+        "status": "awaiting_confirmation",
+    }
+
+
+async def handle_confirmation_node(state: dict) -> dict:
+    """
+    Verifica a resposta do cliente à confirmação dos dados.
+    - "sim" / confirma → prossegue para registro
+    - "não" / corrigir → volta para coleta de dados do cliente
+    - Indefinido → pede esclarecimento
+    """
+    messages = state.get("messages", [])
+    client_phone = state.get("client_phone", "")
+
+    user_messages = [m for m in messages if m.get("role") == "user"]
+    latest = user_messages[-1].get("content", "").lower().strip() if user_messages else ""
+
+    confirmed_words = {
+        "sim", "s", "confirmo", "pode", "ok", "certo", "isso", "correto", "tudo certo", "cadastra",
+    }
+    rejected_words = {  # noqa: E501
+        "não", "nao", "n", "errado", "errada", "corrigir", "mudar", "alterar", "refazer",
+    }
+
+    if any(w in latest for w in confirmed_words):
+        return {"confirmation_status": "confirmed"}
+
+    if any(w in latest for w in rejected_words):
+        msg = "Tudo bem! Vamos recomeçar a coleta. Pode me confirmar seu nome completo?"
+        await notification_service.send_whatsapp_message(client_phone, msg)
+        return {
+            "confirmation_status": "rejected",
+            "client_data": {},
+            "policy_data": {},
+            "client_data_complete": False,
+            "policy_data_complete": False,
+            "messages": messages + [{"role": "assistant", "content": msg}],
+            "status": "collecting_client",
+        }
+
+    # Resposta ambígua
+    msg = "Pode confirmar: responda *sim* para cadastrar ou *não* para corrigir algum dado."
+    await notification_service.send_whatsapp_message(client_phone, msg)
+    return {
+        "confirmation_status": "unclear",
+        "messages": messages + [{"role": "assistant", "content": msg}],
+    }
+
+
+def route_confirmation(state: dict) -> str:
+    return state.get("confirmation_status", "unclear")
+
+
+# ---------------------------------------------------------------------------
+# Registro no banco
+# ---------------------------------------------------------------------------
+
+async def register_node(state: dict) -> dict:
+    """
+    Cria o cliente e a apólice no banco de dados.
+    Em caso de falha: incrementa retry_count. Se >= _MAX_RETRIES, escala para corretor.
+    """
+    client_phone = state.get("client_phone", "")
+    client_data = state.get("client_data", {})
+    policy_data = state.get("policy_data", {})
+    retry_count = state.get("retry_count", 0)
+
+    try:
+        # Cria / busca seguradora
+        insurer_id = await get_or_create_insurer(policy_data.get("insurer", "Não informada"))
+
+        # Cria cliente (retorna existente se CPF já cadastrado)
+        client_id = await create_client(
+            full_name=client_data.get("full_name", ""),
+            cpf_cnpj=client_data.get("cpf", ""),
+            phone_whatsapp=client_phone,
+            email=client_data.get("email"),
+        )
+
+        # Cria apólice
+        policy_id = await create_policy(
+            client_id=client_id,
+            insurer_id=insurer_id,
+            policy_number=policy_data.get("policy_number", ""),
+            policy_type=policy_data.get("policy_type", "auto"),
+            item_description=policy_data.get("item_description", ""),
+            end_date=policy_data.get("end_date", ""),
+            start_date=policy_data.get("start_date"),
+            seller_phone=settings.broker_notification_phone,
+        )
+
+        logger.info(
+            "Onboarding concluído: client_id=%s policy_id=%s phone=%s",
+            client_id, policy_id, client_phone,
+        )
+        return {
+            "client_id": client_id,
+            "policy_id": policy_id,
+            "registered": True,
+            "status": "registered",
+        }
+
+    except Exception as exc:
+        logger.error("Erro ao registrar cliente/apólice para %s: %s", client_phone, exc)
+        new_retry = retry_count + 1
+        if new_retry >= _MAX_RETRIES:
+            return {
+                "retry_count": new_retry,
+                "failed": True,
+                "status": "failed",
+            }
+        return {"retry_count": new_retry}
+
+
+def route_after_register(state: dict) -> str:
+    if state.get("failed"):
+        return "escalate"
+    if state.get("registered"):
+        return "welcome"
+    return "escalate"  # fallback
+
+
+# ---------------------------------------------------------------------------
+# Boas-vindas ao cliente
+# ---------------------------------------------------------------------------
+
+async def welcome_node(state: dict) -> dict:
+    """Envia mensagem de boas-vindas ao cliente após cadastro concluído."""
+    client_phone = state.get("client_phone", "")
+    messages = state.get("messages", [])
+
+    await notification_service.send_whatsapp_message(client_phone, WELCOME_MESSAGE)
+    return {
+        "messages": messages + [{"role": "assistant", "content": WELCOME_MESSAGE}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Notificação do corretor
+# ---------------------------------------------------------------------------
+
+async def notify_seller_node(state: dict) -> dict:
+    """Envia resumo do novo cadastro ao BROKER_NOTIFICATION_PHONE."""
+    client_data = state.get("client_data", {})
+    policy_data = state.get("policy_data", {})
+    client_phone = state.get("client_phone", "")
+
+    alert = BROKER_NOTIFICATION.format(
+        full_name=client_data.get("full_name", ""),
+        cpf=client_data.get("cpf", ""),
+        phone=client_phone,
+        insurer=policy_data.get("insurer", ""),
+        policy_number=policy_data.get("policy_number", ""),
+        item_description=policy_data.get("item_description", ""),
+        end_date=policy_data.get("end_date", ""),
+        registered_at=datetime.now(UTC).strftime("%d/%m/%Y às %Hh%M"),
+    )
+    await notification_service.send_broker_alert(alert)
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Escalada para corretor (falha após max retries)
+# ---------------------------------------------------------------------------
+
+async def escalate_node(state: dict) -> dict:
+    """Notifica corretor e informa cliente que o cadastro manual será necessário."""
+    client_phone = state.get("client_phone", "")
+
+    await notification_service.send_whatsapp_message(client_phone, ESCALATION_MESSAGE)
+
+    alert = BROKER_ESCALATION_ALERT.format(
+        phone=client_phone,
+        reason="Falha no cadastro automático após múltiplas tentativas.",
+    )
+    await notification_service.send_broker_alert(alert)
+
+    return {"failed": True, "status": "failed"}
+
+
+# ---------------------------------------------------------------------------
+# Cancelamento (comando /cancelar do corretor)
+# ---------------------------------------------------------------------------
+
+async def cancel_onboarding_node(state: dict) -> dict:
+    """Cancela onboarding em andamento e notifica o cliente."""
+    client_phone = state.get("client_phone", "")
+    await notification_service.send_whatsapp_message(client_phone, CANCEL_MESSAGE)
+    return {"failed": True, "status": "failed"}

--- a/agents/onboarding/prompts.py
+++ b/agents/onboarding/prompts.py
@@ -91,14 +91,6 @@ Gere apenas a mensagem de pergunta, sem explicações adicionais. Em português 
 # Templates de mensagem
 # ---------------------------------------------------------------------------
 
-PUSH_GREETING = """Olá! Sou o assistente da corretora. O seu corretor pediu pra eu fazer seu cadastro rapidinho aqui no WhatsApp. 😊
-
-Pode ser agora? Vai levar só alguns minutos!"""
-
-PULL_GREETING = """Olá! Seja bem-vindo(a) à corretora. Vou fazer seu cadastro para que possamos te atender.
-
-Pode me confirmar seu nome completo?"""
-
 CONFIRMATION_MESSAGE = """Perfeito! Vou confirmar os dados antes de finalizar o cadastro:
 
 👤 *Nome:* {full_name}

--- a/agents/onboarding/prompts.py
+++ b/agents/onboarding/prompts.py
@@ -1,0 +1,142 @@
+"""
+Prompts do Agente de Onboarding.
+"""
+
+ONBOARDING_SYSTEM_PROMPT = """Você é o assistente de cadastro da corretora de seguros.
+Seu papel é coletar os dados do novo cliente e da apólice de forma natural, como uma conversa, não como um formulário.
+
+COMPORTAMENTO:
+- Peça os dados um a um, de forma amigável e direta.
+- Se o cliente errar um dado (ex: CPF inválido), explique gentilmente e peça novamente.
+- Confirme os dados ao final antes de registrar.
+- Seja breve nas perguntas — o cliente está no WhatsApp.
+
+AÇÕES PROIBIDAS:
+- Não registre sem confirmação explícita do cliente.
+- Não prometa coberturas ou condições da apólice.
+- Não peça dados além do necessário (sem cartão, conta bancária, senhas).
+- Não se identifique como IA a menos que o cliente pergunte diretamente."""
+
+
+# ---------------------------------------------------------------------------
+# Extração de dados do cliente
+# ---------------------------------------------------------------------------
+
+EXTRACT_CLIENT_DATA_PROMPT = """Analise o histórico da conversa e extraia os dados pessoais do cliente.
+
+Histórico:
+{messages}
+
+Retorne apenas o JSON:
+{{
+  "full_name": "<nome completo ou null>",
+  "cpf": "<CPF com ou sem formatação ou null>",
+  "email": "<email ou null>",
+  "missing_fields": ["<campos que ainda faltam: full_name, cpf>"]
+}}
+
+Campos obrigatórios: full_name, cpf.
+Se o campo não foi informado na conversa, use null e inclua em missing_fields."""
+
+
+GENERATE_CLIENT_QUESTION_PROMPT = """Você é o assistente de cadastro de uma corretora de seguros.
+Gere UMA pergunta natural e amigável para coletar os seguintes dados que ainda faltam: {missing_fields}.
+
+Histórico da conversa até agora:
+{messages}
+
+{error_context}
+
+Gere apenas a mensagem de pergunta, sem explicações adicionais. Em português (pt-BR)."""
+
+
+# ---------------------------------------------------------------------------
+# Extração de dados da apólice
+# ---------------------------------------------------------------------------
+
+EXTRACT_POLICY_DATA_PROMPT = """Analise o histórico da conversa e extraia os dados da apólice de seguro.
+
+Histórico:
+{messages}
+
+Retorne apenas o JSON:
+{{
+  "insurer": "<nome da seguradora ou null>",
+  "policy_type": "<tipo: auto, vida, residência, viagem ou null>",
+  "item_description": "<descrição do item segurado (ex: Toyota Yaris / ABC1234) ou null>",
+  "policy_number": "<número da apólice ou null>",
+  "end_date": "<data de vencimento no formato DD/MM/YYYY ou YYYY-MM-DD ou null>",
+  "start_date": "<data de início ou null>",
+  "missing_fields": ["<campos que faltam: insurer, item_description, policy_number, end_date>"]
+}}
+
+Campos obrigatórios: insurer, item_description, policy_number, end_date.
+Se o campo não foi informado, use null e inclua em missing_fields."""
+
+
+GENERATE_POLICY_QUESTION_PROMPT = """Você é o assistente de cadastro de uma corretora de seguros.
+O cliente acabou de confirmar os dados pessoais. Agora precisamos dos dados da apólice.
+
+Gere UMA pergunta natural para coletar os seguintes dados que ainda faltam: {missing_fields}.
+
+Histórico da conversa:
+{messages}
+
+{error_context}
+
+Gere apenas a mensagem de pergunta, sem explicações adicionais. Em português (pt-BR)."""
+
+
+# ---------------------------------------------------------------------------
+# Templates de mensagem
+# ---------------------------------------------------------------------------
+
+PUSH_GREETING = """Olá! Sou o assistente da corretora. O seu corretor pediu pra eu fazer seu cadastro rapidinho aqui no WhatsApp. 😊
+
+Pode ser agora? Vai levar só alguns minutos!"""
+
+PULL_GREETING = """Olá! Seja bem-vindo(a) à corretora. Vou fazer seu cadastro para que possamos te atender.
+
+Pode me confirmar seu nome completo?"""
+
+CONFIRMATION_MESSAGE = """Perfeito! Vou confirmar os dados antes de finalizar o cadastro:
+
+👤 *Nome:* {full_name}
+📄 *CPF:* {cpf}
+🏢 *Seguradora:* {insurer}
+📋 *Apólice:* {policy_number}
+🚗 *Item segurado:* {item_description}
+📅 *Vencimento:* {end_date}
+
+Está tudo correto? Responda *sim* para confirmar ou *não* para corrigir."""
+
+WELCOME_MESSAGE = """Cadastro realizado com sucesso! ✅
+
+Seus dados estão registrados e você já pode contar com nosso atendimento via WhatsApp.
+
+Qualquer dúvida sobre o seguro, é só chamar aqui! 😊"""
+
+BROKER_NOTIFICATION = """✅ *NOVO CLIENTE CADASTRADO*
+
+👤 *Nome:* {full_name}
+📄 *CPF:* {cpf}
+📱 *WhatsApp:* {phone}
+🏢 *Seguradora:* {insurer}
+📋 *Apólice:* {policy_number}
+🚗 *Item:* {item_description}
+📅 *Vencimento:* {end_date}
+
+Cadastrado em: {registered_at}"""
+
+ESCALATION_MESSAGE = """Não conseguimos concluir seu cadastro automaticamente. 😔
+
+Um dos nossos atendentes vai entrar em contato com você em breve para finalizar. Obrigado pela paciência!"""
+
+BROKER_ESCALATION_ALERT = """⚠️ *ONBOARDING INCOMPLETO — AÇÃO NECESSÁRIA*
+
+📱 *Cliente:* {phone}
+❌ *Motivo:* {reason}
+
+Por favor, entre em contato para finalizar o cadastro manualmente."""
+
+CANCEL_MESSAGE = """Tudo bem! Cancelei o processo de cadastro. Quando quiser retomar, é só chamar! 😊"""

--- a/agents/onboarding/state.py
+++ b/agents/onboarding/state.py
@@ -28,4 +28,5 @@ class OnboardingState(TypedDict):
 
     # Conversa
     messages: list[dict]        # histórico: [{role, content, ts?}]
-    status: str                 # collecting_client | collecting_policy | validating | registered | failed
+    status: str                 # collecting_client | collecting_policy | awaiting_confirmation | registered | failed | cancel
+    confirmation_status: str    # confirmed | rejected | unclear

--- a/agents/onboarding/state.py
+++ b/agents/onboarding/state.py
@@ -1,0 +1,31 @@
+"""
+State schema do Agente de Onboarding.
+"""
+from typing import TypedDict
+
+
+class OnboardingState(TypedDict):
+    # Identificação
+    conversation_id: str
+    client_phone: str           # número do cliente sendo cadastrado
+    push_mode: bool             # True = iniciado pelo corretor via /cadastrar
+
+    # Dados coletados em conversa
+    client_data: dict           # full_name, cpf, email
+    policy_data: dict           # insurer, policy_type, item_description, policy_number, end_date, start_date
+
+    # Controle de fluxo
+    client_data_complete: bool
+    policy_data_complete: bool
+    validation_errors: list[str]
+    retry_count: int            # tentativas de correção de dados inválidos
+
+    # Resultado
+    client_id: str              # gerado após registro no banco
+    policy_id: str              # gerado após registro no banco
+    registered: bool
+    failed: bool                # onboarding cancelado ou falhou após max retries
+
+    # Conversa
+    messages: list[dict]        # histórico: [{role, content, ts?}]
+    status: str                 # collecting_client | collecting_policy | validating | registered | failed

--- a/agents/onboarding/state.py
+++ b/agents/onboarding/state.py
@@ -1,7 +1,19 @@
 """
 State schema do Agente de Onboarding.
 """
-from typing import TypedDict
+from typing import Literal, TypedDict
+
+OnboardingStatus = Literal[
+    "collecting_client",
+    "collecting_policy",
+    "awaiting_confirmation",
+    "registered",
+    "failed",
+    "cancel",
+    "",
+]
+
+ConfirmationStatus = Literal["confirmed", "rejected", "unclear", ""]
 
 
 class OnboardingState(TypedDict):
@@ -28,5 +40,5 @@ class OnboardingState(TypedDict):
 
     # Conversa
     messages: list[dict]        # histórico: [{role, content, ts?}]
-    status: str                 # collecting_client | collecting_policy | awaiting_confirmation | registered | failed | cancel
-    confirmation_status: str    # confirmed | rejected | unclear
+    status: OnboardingStatus
+    confirmation_status: ConfirmationStatus

--- a/agents/orchestrator/nodes.py
+++ b/agents/orchestrator/nodes.py
@@ -8,6 +8,7 @@ import logging
 import redis.asyncio as aioredis
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from agents.llm import get_llm as _get_llm_factory
 from agents.orchestrator.prompts import INTENT_DETECTION_PROMPT
 from models.config import settings
 from services import notification_service
@@ -26,15 +27,16 @@ def _get_redis() -> aioredis.Redis:
     return _redis_client
 
 
-from agents.llm import get_llm as _get_llm_factory
-
-
 def _get_llm():
     return _get_llm_factory(max_tokens=256)
 
 
 def _conversation_key(phone: str) -> str:
     return f"claim_conversation:{phone}"
+
+
+def _onboarding_key(phone: str) -> str:
+    return f"onboarding_conversation:{phone}"
 
 
 # ---------------------------------------------------------------------------
@@ -65,6 +67,36 @@ async def delete_conversation_state(phone: str) -> None:
     """Remove o estado da conversa do Redis (sinistro encerrado)."""
     redis = _get_redis()
     await redis.delete(_conversation_key(phone))
+
+
+# ---------------------------------------------------------------------------
+# Gestão de estado de onboarding no Redis
+# ---------------------------------------------------------------------------
+
+async def load_onboarding_state(phone: str) -> dict | None:
+    """Carrega estado de onboarding ativo do Redis. Retorna None se não existir."""
+    redis = _get_redis()
+    raw = await redis.get(_onboarding_key(phone))
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Estado de onboarding corrompido no Redis para %s — removendo", phone)
+        await redis.delete(_onboarding_key(phone))
+        return None
+
+
+async def save_onboarding_state(phone: str, state: dict) -> None:
+    """Persiste o estado de onboarding no Redis (TTL: 30 dias)."""
+    redis = _get_redis()
+    await redis.set(_onboarding_key(phone), json.dumps(state), ex=_CONVERSATION_TTL)
+
+
+async def delete_onboarding_state(phone: str) -> None:
+    """Remove o estado de onboarding do Redis (cadastro concluído ou cancelado)."""
+    redis = _get_redis()
+    await redis.delete(_onboarding_key(phone))
 
 
 # ---------------------------------------------------------------------------

--- a/agents/orchestrator/prompts.py
+++ b/agents/orchestrator/prompts.py
@@ -6,9 +6,10 @@ INTENT_DETECTION_PROMPT = """
 Você é o orquestrador de atendimento de uma corretora de seguros.
 Analise a mensagem do cliente e classifique em uma das categorias:
 
-- "claim"   → sinistro, acidente, roubo, dano, guincho, pane, vidro quebrado, assistência
-- "faq"     → dúvida geral sobre cobertura, vencimento, boleto, documentos, apólice
-- "unknown" → não identificado, reclamação, assunto fora do escopo, saudação sem contexto
+- "claim"      → sinistro, acidente, roubo, dano, guincho, pane, vidro quebrado, assistência
+- "onboarding" → cadastro, registrar, novo cliente, quero me cadastrar, fazer meu cadastro
+- "faq"        → dúvida geral sobre cobertura, vencimento, boleto, documentos, apólice
+- "unknown"    → não identificado, reclamação, assunto fora do escopo, saudação sem contexto
 
 Retorne apenas o JSON: {{"intent": "<categoria>", "confidence": <0.0-1.0>}}
 

--- a/api/routes/webhook.py
+++ b/api/routes/webhook.py
@@ -3,10 +3,15 @@ Rota de webhook WhatsApp.
 Recebe eventos do Evolution API e roteia para o agente adequado.
 
 Roteamento:
-- Cliente com renovação ativa (status 'contacted') → Agente de Renovação (M4)
-- Demais mensagens → Agente de Sinistros / Orquestrador (M2)
+- Mensagem do corretor com /cadastrar <numero> → inicia onboarding (push)
+- Mensagem do corretor com /cancelar <numero>  → cancela onboarding em andamento
+- Cliente com onboarding ativo                 → Agente de Onboarding (M3)
+- Cliente com renovação ativa (contacted)      → Agente de Renovação (M4)
+- Novo cliente sem cadastro + intenção onboarding → Agente de Onboarding (M3, pull)
+- Demais mensagens                             → Agente de Sinistros / Orquestrador (M2)
 """
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 
@@ -16,16 +21,21 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from agents.claims.graph import build_claims_graph
+from agents.onboarding.graph import build_onboarding_graph
 from agents.orchestrator.nodes import (
     delete_conversation_state,
+    delete_onboarding_state,
     detect_intent_node,
     faq_handler_node,
     human_handoff_node,
     load_conversation_state,
+    load_onboarding_state,
     save_conversation_state,
+    save_onboarding_state,
 )
 from agents.renewal.graph import get_renewal_graph
 from api.middleware.auth import verify_evolution_webhook
+from models.config import settings
 from models.database import Client, get_db
 from services import claim_service, notification_service
 from services.renewal_service import RenewalService
@@ -34,6 +44,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _claims_graph = build_claims_graph()
+_onboarding_graph = build_onboarding_graph()
+
+_CMD_CADASTRAR = re.compile(r"^/cadastrar\s+(\d+)", re.IGNORECASE)
+_CMD_CANCELAR  = re.compile(r"^/cancelar\s+(\d+)", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +111,34 @@ async def whatsapp_webhook(
 
     logger.info("Mensagem de %s (%s): %s", phone, client_name, text[:80])
 
+    # ---------------------------------------------------------------------------
+    # Comandos do corretor (apenas de BROKER_NOTIFICATION_PHONE)
+    # ---------------------------------------------------------------------------
+    if phone == settings.broker_notification_phone:
+        cmd_cadastrar = _CMD_CADASTRAR.match(text.strip())
+        if cmd_cadastrar:
+            target_phone = cmd_cadastrar.group(1)
+            await _handle_broker_cadastrar(target_phone)
+            return {"status": "command_cadastrar", "target": target_phone}
+
+        cmd_cancelar = _CMD_CANCELAR.match(text.strip())
+        if cmd_cancelar:
+            target_phone = cmd_cancelar.group(1)
+            await _handle_broker_cancelar(target_phone)
+            return {"status": "command_cancelar", "target": target_phone}
+
+    # ---------------------------------------------------------------------------
+    # Onboarding ativo para este cliente? (M3)
+    # ---------------------------------------------------------------------------
+    onboarding_state = await load_onboarding_state(phone)
+    if onboarding_state is not None:
+        try:
+            await _resume_onboarding(phone=phone, text=text, existing_state=onboarding_state)
+        except Exception:
+            logger.exception("Erro ao retomar onboarding para %s", phone)
+            return {"status": "error_onboarding", "phone": phone}
+        return {"status": "routed_to_onboarding", "phone": phone}
+
     # Verifica se há renovação ativa para o cliente (M4)
     result = await db.execute(
         sa_select(Client).where(Client.phone_whatsapp == phone)
@@ -139,6 +181,113 @@ async def whatsapp_webhook(
     return {"status": "received", "phone": phone}
 
 
+# ---------------------------------------------------------------------------
+# Handlers de comandos do corretor
+# ---------------------------------------------------------------------------
+
+async def _handle_broker_cadastrar(target_phone: str) -> None:
+    """
+    Inicia o onboarding em modo push para o número informado pelo corretor.
+    Cria estado inicial no Redis e aciona o grafo.
+    """
+    logger.info("Comando /cadastrar para %s", target_phone)
+
+    existing = await load_onboarding_state(target_phone)
+    if existing and existing.get("status") not in ("registered", "failed", ""):
+        await notification_service.send_broker_alert(
+            f"⚠️ Já existe um cadastro em andamento para {target_phone}."
+        )
+        return
+
+    initial_state: dict = {
+        "conversation_id": str(uuid.uuid4()),
+        "client_phone": target_phone,
+        "push_mode": True,
+        "client_data": {},
+        "policy_data": {},
+        "client_data_complete": False,
+        "policy_data_complete": False,
+        "validation_errors": [],
+        "retry_count": 0,
+        "client_id": "",
+        "policy_id": "",
+        "registered": False,
+        "failed": False,
+        "messages": [],
+        "status": "",
+    }
+
+    final_state = await _onboarding_graph.ainvoke(initial_state)
+    await _persist_or_close_onboarding(target_phone, final_state)
+
+
+async def _handle_broker_cancelar(target_phone: str) -> None:
+    """
+    Cancela onboarding ativo para o número informado pelo corretor.
+    """
+    logger.info("Comando /cancelar para %s", target_phone)
+
+    existing = await load_onboarding_state(target_phone)
+    if not existing or existing.get("status") in ("registered", "failed"):
+        await notification_service.send_broker_alert(
+            f"ℹ️ Nenhum cadastro ativo encontrado para {target_phone}."
+        )
+        return
+
+    cancel_state = {**existing, "status": "cancel"}
+    await _onboarding_graph.ainvoke(cancel_state)
+    await delete_onboarding_state(target_phone)
+    logger.info("Onboarding cancelado para %s", target_phone)
+
+
+# ---------------------------------------------------------------------------
+# Handlers do agente de onboarding (M3)
+# ---------------------------------------------------------------------------
+
+async def _resume_onboarding(phone: str, text: str, existing_state: dict) -> None:
+    """Retoma onboarding ativo com a nova mensagem do cliente."""
+    messages = existing_state.get("messages", [])
+    messages.append({"role": "user", "content": text, "ts": datetime.now(UTC).isoformat()})
+    updated_state = {**existing_state, "messages": messages}
+
+    final_state = await _onboarding_graph.ainvoke(updated_state)
+    await _persist_or_close_onboarding(phone, final_state)
+
+
+async def _start_onboarding_pull(phone: str, text: str) -> None:
+    """Inicia onboarding em modo pull (cliente chegou sem cadastro com intenção de cadastrar)."""
+    logger.info("Iniciando onboarding pull para %s", phone)
+
+    initial_state: dict = {
+        "conversation_id": str(uuid.uuid4()),
+        "client_phone": phone,
+        "push_mode": False,
+        "client_data": {},
+        "policy_data": {},
+        "client_data_complete": False,
+        "policy_data_complete": False,
+        "validation_errors": [],
+        "retry_count": 0,
+        "client_id": "",
+        "policy_id": "",
+        "registered": False,
+        "failed": False,
+        "messages": [{"role": "user", "content": text, "ts": datetime.now(UTC).isoformat()}],
+        "status": "",
+    }
+
+    final_state = await _onboarding_graph.ainvoke(initial_state)
+    await _persist_or_close_onboarding(phone, final_state)
+
+
+async def _persist_or_close_onboarding(phone: str, state: dict) -> None:
+    """Persiste estado de onboarding no Redis ou remove se concluído/cancelado."""
+    if state.get("registered") or state.get("failed"):
+        await delete_onboarding_state(phone)
+    else:
+        await save_onboarding_state(phone, state)
+
+
 async def _handle_message(phone: str, client_name: str, text: str) -> None:
     """
     Orquestra o processamento da mensagem (M2):
@@ -149,12 +298,19 @@ async def _handle_message(phone: str, client_name: str, text: str) -> None:
     # Lookup do cliente no banco
     client = await claim_service.get_client_by_phone(phone)
     if not client:
-        logger.info("Cliente não cadastrado: %s — enviando mensagem de boas-vindas", phone)
-        await notification_service.send_whatsapp_message(
-            phone,
-            "Olá! Para que possamos ajudá-lo, por favor entre em contato com a corretora "
-            "para cadastrar seus dados. 😊",
-        )
+        # Detecta se o cliente quer se cadastrar (pull mode)
+        intent_state = await detect_intent_node({"message": text, "client_phone": phone})
+        if intent_state.get("intent") == "onboarding":
+            await _start_onboarding_pull(phone=phone, text=text)
+        else:
+            logger.info(
+                "Cliente não cadastrado: %s — intenção não identificada como onboarding", phone
+            )
+            await notification_service.send_whatsapp_message(
+                phone,
+                "Olá! Para que possamos ajudá-lo, por favor entre em contato com a corretora "
+                "para cadastrar seus dados. 😊",
+            )
         return
 
     client_id = client["id"]
@@ -189,6 +345,13 @@ async def _handle_message(phone: str, client_name: str, text: str) -> None:
             client_id=client_id,
             client_name=client_db_name,
             text=text,
+        )
+    elif intent == "onboarding":
+        # Cliente já cadastrado pedindo cadastro — informa que já existe
+        await notification_service.send_whatsapp_message(
+            phone,
+            "Olá! Seus dados já estão cadastrados em nosso sistema. "
+            "Se precisar de ajuda com alguma apólice ou sinistro, é só me avisar! 😊",
         )
     elif intent == "faq":
         await faq_handler_node({

--- a/api/routes/webhook.py
+++ b/api/routes/webhook.py
@@ -215,6 +215,7 @@ async def _handle_broker_cadastrar(target_phone: str) -> None:
         "failed": False,
         "messages": [],
         "status": "",
+        "confirmation_status": "",
     }
 
     final_state = await _onboarding_graph.ainvoke(initial_state)
@@ -274,6 +275,7 @@ async def _start_onboarding_pull(phone: str, text: str) -> None:
         "failed": False,
         "messages": [{"role": "user", "content": text, "ts": datetime.now(UTC).isoformat()}],
         "status": "",
+        "confirmation_status": "",
     }
 
     final_state = await _onboarding_graph.ainvoke(initial_state)

--- a/project_status.md
+++ b/project_status.md
@@ -12,7 +12,7 @@
 | M0 — Documentação e Planejamento | Fev/2026 | Arquitetura, tese, casos de uso, roadmap | 🟡 Em andamento |
 | M1 — Fundação | Semanas 1–3 | Infra, Evolution API (WhatsApp), cadastro de carteira | ✅ Concluído (código) |
 | M2 — Agente de Sinistro Simples E2E | Semanas 3–6 | Sinistro simples do FNOL ao encerramento via WhatsApp | ✅ Validado E2E com Docker + Gemini (aguarda chip WhatsApp) |
-| M3 — Agente de Onboarding | Semanas 5–8 | Onboarding de novo cliente via WhatsApp + cadastro de apólice | 🟡 Em andamento |
+| M3 — Agente de Onboarding | Semanas 5–8 | Onboarding de novo cliente via WhatsApp + cadastro de apólice | ✅ Concluído (código) |
 | M4 — Agente de Renovação | Semanas 7–10 | Régua de renovação proativa + qualificação de lead para vendedor | ✅ Concluído (código) |
 | **MVP** | **Mês 3** | **Três agentes em produção, primeira corretora pagante** | ⬜ Não iniciado |
 | **V1** | **Mês 6** | **Grafo de memória por cliente, relacionamento proativo** | ⬜ Não iniciado |
@@ -113,15 +113,15 @@
 
 ### Entregas esperadas
 
-- [ ] `OnboardingService` com `create_client` e `create_policy` (`services/onboarding_service.py`)
-- [ ] `OnboardingState` (TypedDict) em `agents/onboarding/state.py`
-- [ ] Subgraph LangGraph do Agente de Onboarding (`agents/onboarding/graph.py`, `nodes.py`, `prompts.py`)
-- [ ] Nós implementados: `contact_client` (push), `collect_client`, `collect_policy`, `validate`, `register`, `welcome`, `notify_seller`
-- [ ] Orquestrador: detectar `/cadastrar`, `/cancelar` e intent `"onboarding"` para novo número
-- [ ] Orquestrador: flag "cliente sem cadastro" no roteamento para claims
-- [ ] Webhook conectado ao agente de onboarding E2E
-- [ ] Testes unitários: collect_client, validate, register, notify
-- [ ] Documentação: `docs/agentes/onboarding.md` ✅ (atualizada com decisões)
+- [x] `OnboardingService` com `create_client` e `create_policy` (`services/onboarding_service.py`)
+- [x] `OnboardingState` (TypedDict) em `agents/onboarding/state.py`
+- [x] Subgraph LangGraph do Agente de Onboarding (`agents/onboarding/graph.py`, `nodes.py`, `prompts.py`)
+- [x] Nós implementados: `contact_client` (push), `collect_client`, `collect_policy`, `confirm`, `handle_confirmation`, `register`, `welcome`, `notify_seller`, `escalate`, `cancel_onboarding`
+- [x] Orquestrador: detectar `/cadastrar`, `/cancelar` e intent `"onboarding"` para novo número
+- [x] Orquestrador: estado de onboarding no Redis (load/save/delete)
+- [x] Webhook conectado ao agente de onboarding E2E (push + pull + comandos do corretor)
+- [x] Testes unitários: collect_client, collect_policy, confirm, handle_confirmation, register, notify, cancel
+- [x] Documentação: `docs/agentes/onboarding.md` ✅ (atualizada com decisões)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ ignore = ["UP017"]  # datetime.UTC requer Python 3.11 — runtime de testes usa 
 [tool.ruff.lint.per-file-ignores]
 "migrations/**" = ["E501"]
 "tests/**" = ["E501"]
+"agents/onboarding/prompts.py" = ["E501"]
+"agents/onboarding/state.py" = ["E501"]
+"agents/claims/prompts.py" = ["E501"]
+"agents/renewal/prompts.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/services/onboarding_service.py
+++ b/services/onboarding_service.py
@@ -1,0 +1,192 @@
+"""
+OnboardingService — criação de clientes e apólices via fluxo de onboarding.
+"""
+import re
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+
+from models.database import AsyncSessionLocal, Client, Insurer, Policy
+
+# ---------------------------------------------------------------------------
+# CPF validation
+# ---------------------------------------------------------------------------
+
+def validate_cpf(cpf: str) -> bool:
+    """Valida CPF brasileiro pelo algoritmo de dígito verificador."""
+    digits = re.sub(r"\D", "", cpf)
+    if len(digits) != 11 or len(set(digits)) == 1:
+        return False
+    # Primeiro dígito verificador
+    total = sum(int(d) * (10 - i) for i, d in enumerate(digits[:9]))
+    first = (total * 10 % 11) % 10
+    if first != int(digits[9]):
+        return False
+    # Segundo dígito verificador
+    total = sum(int(d) * (11 - i) for i, d in enumerate(digits[:10]))
+    second = (total * 10 % 11) % 10
+    return second == int(digits[10])
+
+
+def format_cpf(cpf: str) -> str:
+    """Normaliza CPF para formato xxx.xxx.xxx-xx."""
+    digits = re.sub(r"\D", "", cpf)
+    if len(digits) == 11:
+        return f"{digits[:3]}.{digits[3:6]}.{digits[6:9]}-{digits[9:]}"
+    return cpf
+
+
+# ---------------------------------------------------------------------------
+# Policy type mapping
+# ---------------------------------------------------------------------------
+
+_POLICY_TYPE_MAP: dict[str, str] = {
+    "auto": "auto",
+    "automóvel": "auto",
+    "automovel": "auto",
+    "carro": "auto",
+    "moto": "auto",
+    "motocicleta": "auto",
+    "vida": "life",
+    "life": "life",
+    "residência": "home",
+    "residencia": "home",
+    "casa": "home",
+    "home": "home",
+    "viagem": "travel",
+    "travel": "travel",
+    "empresarial": "business",
+    "business": "business",
+}
+
+
+def normalize_policy_type(raw: str) -> str:
+    return _POLICY_TYPE_MAP.get(raw.lower().strip(), "auto")
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+async def get_or_create_insurer(name: str) -> str:
+    """
+    Busca seguradora por nome (correspondência parcial, case-insensitive).
+    Se não existir, cria um registro mínimo com integration_type='manual'.
+    Retorna o UUID como string.
+    """
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(Insurer))
+        insurers = result.scalars().all()
+        name_lower = name.lower().strip()
+        for ins in insurers:
+            if name_lower in ins.name.lower() or ins.name.lower() in name_lower:
+                return str(ins.id)
+
+        # Cria seguradora nova (MVP — será refinada pelo corretor depois)
+        code = re.sub(r"\s+", "_", name_lower)[:30]
+        new_insurer = Insurer(
+            id=uuid.uuid4(),
+            name=name.strip().title(),
+            code=code,
+            integration_type="manual",
+            two_fa_method="none",
+            active=True,
+        )
+        session.add(new_insurer)
+        await session.commit()
+        return str(new_insurer.id)
+
+
+async def get_client_by_cpf(cpf: str) -> dict | None:
+    """Retorna dados básicos do cliente pelo CPF (ignora formatação)."""
+    digits = re.sub(r"\D", "", cpf)
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(Client))
+        clients = result.scalars().all()
+        for client in clients:
+            stored = re.sub(r"\D", "", str(client.cpf_cnpj or ""))
+            if stored == digits:
+                return {"id": str(client.id), "name": client.full_name}
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+async def create_client(
+    full_name: str,
+    cpf_cnpj: str,
+    phone_whatsapp: str,
+    email: str | None = None,
+) -> str:
+    """
+    Cria o cliente no banco.
+    Se já existir um cliente com o mesmo CPF, retorna o ID existente.
+    Retorna o UUID como string.
+    """
+    existing = await get_client_by_cpf(cpf_cnpj)
+    if existing:
+        return existing["id"]
+
+    async with AsyncSessionLocal() as session:
+        client = Client(
+            id=uuid.uuid4(),
+            full_name=full_name.strip().title(),
+            cpf_cnpj=format_cpf(cpf_cnpj),
+            phone_whatsapp=phone_whatsapp,
+            email=email,
+        )
+        session.add(client)
+        await session.commit()
+        return str(client.id)
+
+
+async def create_policy(
+    client_id: str,
+    insurer_id: str,
+    policy_number: str,
+    policy_type: str,
+    item_description: str,
+    end_date: str,
+    start_date: str | None = None,
+    seller_phone: str | None = None,
+) -> str:
+    """
+    Cria a apólice no banco vinculada ao cliente.
+    end_date e start_date no formato YYYY-MM-DD ou DD/MM/YYYY.
+    Retorna o UUID como string.
+    """
+    from datetime import date
+
+    def parse_date(raw: str) -> date | None:
+        if not raw:
+            return None
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y"):
+            try:
+                return datetime.strptime(raw, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+    end = parse_date(end_date)
+    start = parse_date(start_date) if start_date else date.today()
+
+    async with AsyncSessionLocal() as session:
+        policy = Policy(
+            id=uuid.uuid4(),
+            client_id=uuid.UUID(client_id),
+            insurer_id=uuid.UUID(insurer_id),
+            policy_number=policy_number.strip(),
+            type=normalize_policy_type(policy_type),
+            item_description=item_description.strip(),
+            status="active",
+            start_date=start,
+            end_date=end,
+            seller_phone=seller_phone,
+            imported_from="manual",
+        )
+        session.add(policy)
+        await session.commit()
+        return str(policy.id)

--- a/services/onboarding_service.py
+++ b/services/onboarding_service.py
@@ -74,9 +74,12 @@ async def get_or_create_insurer(name: str) -> str:
     Busca seguradora por nome (correspondência parcial, case-insensitive).
     Se não existir, cria um registro mínimo com integration_type='manual'.
     Retorna o UUID como string.
+
+    Nota: carrega todas as seguradoras ativas em memória para o match bidirecional.
+    Aceitável no MVP (dezenas de registros); revisar se a tabela crescer.
     """
     async with AsyncSessionLocal() as session:
-        result = await session.execute(select(Insurer))
+        result = await session.execute(select(Insurer).where(Insurer.active.is_(True)))
         insurers = result.scalars().all()
         name_lower = name.lower().strip()
         for ins in insurers:
@@ -100,14 +103,14 @@ async def get_or_create_insurer(name: str) -> str:
 
 async def get_client_by_cpf(cpf: str) -> dict | None:
     """Retorna dados básicos do cliente pelo CPF (ignora formatação)."""
-    digits = re.sub(r"\D", "", cpf)
+    formatted = format_cpf(cpf)
     async with AsyncSessionLocal() as session:
-        result = await session.execute(select(Client))
-        clients = result.scalars().all()
-        for client in clients:
-            stored = re.sub(r"\D", "", str(client.cpf_cnpj or ""))
-            if stored == digits:
-                return {"id": str(client.id), "name": client.full_name}
+        result = await session.execute(
+            select(Client).where(Client.cpf_cnpj == formatted)
+        )
+        client = result.scalar_one_or_none()
+        if client:
+            return {"id": str(client.id), "name": client.full_name}
     return None
 
 

--- a/tests/unit/test_onboarding_agent.py
+++ b/tests/unit/test_onboarding_agent.py
@@ -193,11 +193,6 @@ def test_route_after_register_failure() -> None:
     assert route_after_register(state) == "escalate"
 
 
-def test_route_after_register_fallback() -> None:
-    state = make_state(registered=False, failed=False)
-    assert route_after_register(state) == "escalate"
-
-
 # ---------------------------------------------------------------------------
 # contact_client_node (push mode)
 # ---------------------------------------------------------------------------
@@ -371,9 +366,12 @@ async def test_confirm_node_sends_summary() -> None:
     ("Sim!", "confirmed"),
     ("ok", "confirmed"),
     ("confirmo", "confirmed"),
+    ("tudo certo", "confirmed"),
     ("não", "rejected"),
     ("nao", "rejected"),
     ("corrigir", "rejected"),
+    ("quero mudar", "rejected"),
+    ("talvez", "unclear"),
 ])
 async def test_handle_confirmation_node(user_message: str, expected_status: str) -> None:
     state = make_state(
@@ -420,8 +418,8 @@ async def test_register_node_success() -> None:
 
 @pytest.mark.asyncio
 async def test_register_node_failure_escalates_after_max_retries() -> None:
+    """Todas as tentativas falham → retorna failed=True sem precisar de retry_count externo."""
     state = make_state(
-        retry_count=2,  # já está na última tentativa
         client_data={"full_name": "João", "cpf": "529.982.247-25"},
         policy_data={"insurer": "Porto", "policy_number": "X", "item_description": "Y", "end_date": "01/01/2027"},
     )
@@ -431,6 +429,38 @@ async def test_register_node_failure_escalates_after_max_retries() -> None:
 
     assert result["failed"] is True
     assert result["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_register_node_retries_internally() -> None:
+    """Falha nas primeiras tentativas mas sucesso na última → registered=True."""
+    state = make_state(
+        client_data={"full_name": "João Silva", "cpf": "529.982.247-25"},
+        policy_data={
+            "insurer": "Porto Seguro", "policy_type": "auto",
+            "item_description": "Toyota Yaris", "policy_number": "12345",
+            "end_date": "31/12/2026", "start_date": None,
+        },
+    )
+
+    call_count = 0
+
+    async def flaky_insurer(_name: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise Exception("timeout")
+        return "insurer-uuid"
+
+    with (
+        patch("agents.onboarding.nodes.get_or_create_insurer", side_effect=flaky_insurer),
+        patch("agents.onboarding.nodes.create_client", AsyncMock(return_value="client-uuid")),
+        patch("agents.onboarding.nodes.create_policy", AsyncMock(return_value="policy-uuid")),
+    ):
+        result = await register_node(state)
+
+    assert result["registered"] is True
+    assert call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_onboarding_agent.py
+++ b/tests/unit/test_onboarding_agent.py
@@ -1,0 +1,476 @@
+"""
+Testes unitários do Agente de Onboarding (M3).
+Usa mocks para LLM e serviços externos — sem dependências de rede ou banco.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agents.onboarding.nodes import (
+    cancel_onboarding_node,
+    collect_client_node,
+    collect_policy_node,
+    confirm_node,
+    contact_client_node,
+    handle_confirmation_node,
+    notify_seller_node,
+    register_node,
+    route_after_register,
+    route_client_collection,
+    route_confirmation,
+    route_entry,
+    route_policy_collection,
+    welcome_node,
+)
+from services.onboarding_service import (
+    format_cpf,
+    normalize_policy_type,
+    validate_cpf,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def make_state(**kwargs) -> dict:
+    """Estado mínimo válido para o agente de onboarding."""
+    base: dict = {
+        "conversation_id": "conv-001",
+        "client_phone": "5517999990001",
+        "push_mode": False,
+        "client_data": {},
+        "policy_data": {},
+        "client_data_complete": False,
+        "policy_data_complete": False,
+        "validation_errors": [],
+        "retry_count": 0,
+        "client_id": "",
+        "policy_id": "",
+        "registered": False,
+        "failed": False,
+        "messages": [],
+        "status": "",
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# validate_cpf
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cpf,expected", [
+    ("529.982.247-25", True),
+    ("52998224725",    True),
+    ("111.111.111-11", False),   # todos iguais
+    ("000.000.000-00", False),
+    ("123.456.789-00", False),   # dígitos errados
+    ("123",            False),   # curto demais
+])
+def test_validate_cpf(cpf: str, expected: bool) -> None:
+    assert validate_cpf(cpf) == expected
+
+
+# ---------------------------------------------------------------------------
+# format_cpf
+# ---------------------------------------------------------------------------
+
+def test_format_cpf_with_digits() -> None:
+    assert format_cpf("52998224725") == "529.982.247-25"
+
+
+def test_format_cpf_already_formatted() -> None:
+    assert format_cpf("529.982.247-25") == "529.982.247-25"
+
+
+# ---------------------------------------------------------------------------
+# normalize_policy_type
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("auto",       "auto"),
+    ("carro",      "auto"),
+    ("moto",       "auto"),
+    ("vida",       "life"),
+    ("residência", "home"),
+    ("casa",       "home"),
+    ("viagem",     "travel"),
+    ("empresarial","business"),
+    ("outro",      "auto"),  # fallback
+])
+def test_normalize_policy_type(raw: str, expected: str) -> None:
+    assert normalize_policy_type(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# route_entry
+# ---------------------------------------------------------------------------
+
+def test_route_entry_registered() -> None:
+    state = make_state(status="registered")
+    assert route_entry(state) == "end"
+
+
+def test_route_entry_failed() -> None:
+    state = make_state(status="failed")
+    assert route_entry(state) == "end"
+
+
+def test_route_entry_awaiting_confirmation() -> None:
+    state = make_state(status="awaiting_confirmation")
+    assert route_entry(state) == "handle_confirmation"
+
+
+def test_route_entry_collecting_policy() -> None:
+    state = make_state(status="collecting_policy")
+    assert route_entry(state) == "collect_policy"
+
+
+def test_route_entry_push_new() -> None:
+    state = make_state(push_mode=True, status="")
+    assert route_entry(state) == "contact_client"
+
+
+def test_route_entry_pull_new() -> None:
+    state = make_state(push_mode=False, status="")
+    assert route_entry(state) == "collect_client"
+
+
+def test_route_entry_cancel() -> None:
+    state = make_state(status="cancel")
+    assert route_entry(state) == "cancel"
+
+
+# ---------------------------------------------------------------------------
+# route_client_collection / route_policy_collection
+# ---------------------------------------------------------------------------
+
+def test_route_client_collection_complete() -> None:
+    assert route_client_collection(make_state(client_data_complete=True)) == "complete"
+
+
+def test_route_client_collection_incomplete() -> None:
+    assert route_client_collection(make_state(client_data_complete=False)) == "incomplete"
+
+
+def test_route_policy_collection_complete() -> None:
+    assert route_policy_collection(make_state(policy_data_complete=True)) == "complete"
+
+
+def test_route_policy_collection_incomplete() -> None:
+    assert route_policy_collection(make_state(policy_data_complete=False)) == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# route_confirmation
+# ---------------------------------------------------------------------------
+
+def test_route_confirmation_confirmed() -> None:
+    assert route_confirmation({"confirmation_status": "confirmed"}) == "confirmed"
+
+
+def test_route_confirmation_rejected() -> None:
+    assert route_confirmation({"confirmation_status": "rejected"}) == "rejected"
+
+
+def test_route_confirmation_unclear() -> None:
+    assert route_confirmation({"confirmation_status": "unclear"}) == "unclear"
+
+
+# ---------------------------------------------------------------------------
+# route_after_register
+# ---------------------------------------------------------------------------
+
+def test_route_after_register_success() -> None:
+    state = make_state(registered=True)
+    assert route_after_register(state) == "welcome"
+
+
+def test_route_after_register_failure() -> None:
+    state = make_state(failed=True)
+    assert route_after_register(state) == "escalate"
+
+
+def test_route_after_register_fallback() -> None:
+    state = make_state(registered=False, failed=False)
+    assert route_after_register(state) == "escalate"
+
+
+# ---------------------------------------------------------------------------
+# contact_client_node (push mode)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_contact_client_node_sends_greeting() -> None:
+    state = make_state(push_mode=True)
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await contact_client_node(state)
+
+    mock_notif.send_whatsapp_message.assert_awaited_once()
+    assert result["status"] == "collecting_client"
+    assert any(m["role"] == "assistant" for m in result["messages"])
+
+
+# ---------------------------------------------------------------------------
+# collect_client_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_collect_client_node_incomplete_asks_question() -> None:
+    state = make_state(messages=[{"role": "user", "content": "Olá"}])
+
+    llm_extract_response = MagicMock()
+    llm_extract_response.content = json.dumps({
+        "full_name": None,
+        "cpf": None,
+        "email": None,
+        "missing_fields": ["full_name", "cpf"],
+    })
+    llm_question_response = MagicMock()
+    llm_question_response.content = "Pode me dizer seu nome completo?"
+
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(side_effect=[llm_extract_response, llm_question_response])
+
+    with (
+        patch("agents.onboarding.nodes._get_llm", return_value=mock_llm),
+        patch("agents.onboarding.nodes.notification_service") as mock_notif,
+    ):
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await collect_client_node(state)
+
+    assert result["client_data_complete"] is False
+    assert result["status"] == "collecting_client"
+    mock_notif.send_whatsapp_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_collect_client_node_complete() -> None:
+    state = make_state(messages=[
+        {"role": "user", "content": "Meu nome é João Silva, CPF 529.982.247-25"},
+    ])
+
+    llm_response = MagicMock()
+    llm_response.content = json.dumps({
+        "full_name": "João Silva",
+        "cpf": "529.982.247-25",
+        "email": None,
+        "missing_fields": [],
+    })
+
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(return_value=llm_response)
+
+    with patch("agents.onboarding.nodes._get_llm", return_value=mock_llm):
+        result = await collect_client_node(state)
+
+    assert result["client_data_complete"] is True
+    assert result["client_data"]["full_name"] == "João Silva"
+
+
+@pytest.mark.asyncio
+async def test_collect_client_node_invalid_cpf() -> None:
+    """CPF inválido deve ser descartado e o campo adicionado a missing_fields."""
+    state = make_state(messages=[
+        {"role": "user", "content": "João Silva, CPF 111.111.111-11"},
+    ])
+
+    llm_extract_response = MagicMock()
+    llm_extract_response.content = json.dumps({
+        "full_name": "João Silva",
+        "cpf": "111.111.111-11",
+        "email": None,
+        "missing_fields": [],
+    })
+    llm_question_response = MagicMock()
+    llm_question_response.content = "Esse CPF parece inválido. Pode conferir?"
+
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(side_effect=[llm_extract_response, llm_question_response])
+
+    with (
+        patch("agents.onboarding.nodes._get_llm", return_value=mock_llm),
+        patch("agents.onboarding.nodes.notification_service") as mock_notif,
+    ):
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await collect_client_node(state)
+
+    assert result["client_data_complete"] is False
+    assert result["client_data"]["cpf"] is None
+
+
+# ---------------------------------------------------------------------------
+# collect_policy_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_collect_policy_node_complete() -> None:
+    state = make_state(
+        status="collecting_policy",
+        client_data_complete=True,
+        messages=[
+            {"role": "user", "content": "Porto Seguro, apólice 12345, Toyota Yaris ABC1234, vence 31/12/2026"},
+        ],
+    )
+
+    llm_response = MagicMock()
+    llm_response.content = json.dumps({
+        "insurer": "Porto Seguro",
+        "policy_type": "auto",
+        "item_description": "Toyota Yaris ABC1234",
+        "policy_number": "12345",
+        "end_date": "31/12/2026",
+        "start_date": None,
+        "missing_fields": [],
+    })
+
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(return_value=llm_response)
+
+    with patch("agents.onboarding.nodes._get_llm", return_value=mock_llm):
+        result = await collect_policy_node(state)
+
+    assert result["policy_data_complete"] is True
+    assert result["policy_data"]["insurer"] == "Porto Seguro"
+    assert result["policy_data"]["policy_number"] == "12345"
+
+
+# ---------------------------------------------------------------------------
+# confirm_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_confirm_node_sends_summary() -> None:
+    state = make_state(
+        client_data={"full_name": "João Silva", "cpf": "529.982.247-25"},
+        policy_data={
+            "insurer": "Porto Seguro",
+            "policy_number": "12345",
+            "item_description": "Toyota Yaris",
+            "end_date": "31/12/2026",
+        },
+    )
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await confirm_node(state)
+
+    mock_notif.send_whatsapp_message.assert_awaited_once()
+    assert result["status"] == "awaiting_confirmation"
+
+
+# ---------------------------------------------------------------------------
+# handle_confirmation_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_message,expected_status", [
+    ("sim", "confirmed"),
+    ("Sim!", "confirmed"),
+    ("ok", "confirmed"),
+    ("confirmo", "confirmed"),
+    ("não", "rejected"),
+    ("nao", "rejected"),
+    ("corrigir", "rejected"),
+])
+async def test_handle_confirmation_node(user_message: str, expected_status: str) -> None:
+    state = make_state(
+        messages=[{"role": "user", "content": user_message}],
+        status="awaiting_confirmation",
+    )
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await handle_confirmation_node(state)
+
+    assert result["confirmation_status"] == expected_status
+
+
+# ---------------------------------------------------------------------------
+# register_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_register_node_success() -> None:
+    state = make_state(
+        client_data={"full_name": "João Silva", "cpf": "529.982.247-25"},
+        policy_data={
+            "insurer": "Porto Seguro",
+            "policy_type": "auto",
+            "item_description": "Toyota Yaris",
+            "policy_number": "12345",
+            "end_date": "31/12/2026",
+            "start_date": None,
+        },
+    )
+
+    with (
+        patch("agents.onboarding.nodes.get_or_create_insurer", AsyncMock(return_value="insurer-uuid")),
+        patch("agents.onboarding.nodes.create_client", AsyncMock(return_value="client-uuid")),
+        patch("agents.onboarding.nodes.create_policy", AsyncMock(return_value="policy-uuid")),
+    ):
+        result = await register_node(state)
+
+    assert result["registered"] is True
+    assert result["client_id"] == "client-uuid"
+    assert result["policy_id"] == "policy-uuid"
+    assert result["status"] == "registered"
+
+
+@pytest.mark.asyncio
+async def test_register_node_failure_escalates_after_max_retries() -> None:
+    state = make_state(
+        retry_count=2,  # já está na última tentativa
+        client_data={"full_name": "João", "cpf": "529.982.247-25"},
+        policy_data={"insurer": "Porto", "policy_number": "X", "item_description": "Y", "end_date": "01/01/2027"},
+    )
+
+    with patch("agents.onboarding.nodes.get_or_create_insurer", AsyncMock(side_effect=Exception("DB error"))):
+        result = await register_node(state)
+
+    assert result["failed"] is True
+    assert result["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# welcome_node / notify_seller_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_welcome_node_sends_message() -> None:
+    state = make_state()
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_whatsapp_message = AsyncMock()
+        await welcome_node(state)
+
+    mock_notif.send_whatsapp_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_notify_seller_node_sends_alert() -> None:
+    state = make_state(
+        client_data={"full_name": "João Silva", "cpf": "529.982.247-25"},
+        policy_data={"insurer": "Porto", "policy_number": "X", "item_description": "Y", "end_date": "01/01/2027"},
+    )
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_broker_alert = AsyncMock()
+        await notify_seller_node(state)
+
+    mock_notif.send_broker_alert.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# cancel_onboarding_node
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cancel_onboarding_node() -> None:
+    state = make_state(status="collecting_client")
+    with patch("agents.onboarding.nodes.notification_service") as mock_notif:
+        mock_notif.send_whatsapp_message = AsyncMock()
+        result = await cancel_onboarding_node(state)
+
+    mock_notif.send_whatsapp_message.assert_awaited_once()
+    assert result["failed"] is True
+    assert result["status"] == "failed"


### PR DESCRIPTION
## Contexto

Implementação completa do M3 — Agente de Onboarding. O agente permite cadastrar novos clientes e apólices diretamente via WhatsApp, tanto por iniciativa do corretor (**modo push**) quanto por chegada espontânea do cliente (**modo pull**).

## O que mudou

### Novos arquivos

| Arquivo | Descrição |
|---|---|
| `services/onboarding_service.py` | CRUD de clientes e apólices; validação de CPF; normalização de tipo de apólice |
| `agents/onboarding/state.py` | `OnboardingState` (TypedDict) com todos os campos de controle |
| `agents/onboarding/prompts.py` | Prompts de extração LLM e templates de mensagem WhatsApp |
| `agents/onboarding/nodes.py` | 11 nós do grafo + funções de roteamento |
| `agents/onboarding/graph.py` | StateGraph LangGraph conectando todos os nós |
| `tests/unit/test_onboarding_agent.py` | 28 testes unitários com mocks de LLM e serviços |

### Arquivos modificados

| Arquivo | Mudança |
|---|---|
| `agents/orchestrator/nodes.py` | Adiciona `load/save/delete_onboarding_state` no Redis; corrige ordem de imports |
| `agents/orchestrator/prompts.py` | Adiciona intent `"onboarding"` ao INTENT_DETECTION_PROMPT |
| `api/routes/webhook.py` | Roteamento completo: comandos `/cadastrar`/`/cancelar`, onboarding ativo, pull mode |
| `pyproject.toml` | Adiciona `prompts.py` e `state.py` ao per-file-ignores de E501 |
| `project_status.md` | M3 marcado como concluído |

### Fluxo implementado

**Modo push** (corretor envia `/cadastrar 5517999990001`):

```
Corretor: /cadastrar 5517999990001
Bot → Cliente: "Olá! Sou o assistente da corretora..."
Cliente: "João Silva"
Bot → Cliente: "Pode me informar seu CPF?"
...
Bot → Cliente: "Confirme os dados: João Silva | 529.982.247-25 | Porto Seguro..."
Cliente: "sim"
Bot → Cliente: "Cadastro realizado com sucesso! ✅"
Bot → Corretor: "✅ NOVO CLIENTE CADASTRADO: João Silva..."
```

**Modo pull** — cliente não cadastrado envia "Quero me cadastrar" → intent `onboarding` → fluxo pull

**Cancelamento** — `/cancelar 5517999990001` → estado removido do Redis + notificação ao cliente

### Nós do grafo

```
entry_router → contact_client (push) ─────────► END (aguarda resposta)
             → collect_client ─── completo ───► collect_policy ─── completo ───► confirm ──► END
             → handle_confirmation ─ "sim" ──► register ──► welcome ──► notify_seller ──► END
                                   └─ "não" ──► END (reset + recomeça)
             → escalate ──► END (falha após 3 tentativas)
             → cancel_onboarding ──► END
```

### Estado no Redis

- Chave: `onboarding_conversation:{phone}` (TTL 30 dias)
- Removido após `registered=True` ou `failed=True`

## Como testar

```bash
# Subir stack
docker compose up api postgres redis -d

# Simular comando push do corretor (BROKER_NOTIFICATION_PHONE)
curl -X POST http://localhost:8000/webhook/whatsapp \
  -H "Content-Type: application/json" -H "apikey: test-api-key" \
  -d '{"event":"messages.upsert","instance":"brokerai","data":{"key":{"remoteJid":"5517999999999@s.whatsapp.net","fromMe":false,"id":"CMD001"},"message":{"conversation":"/cadastrar 5517999990002"},"messageType":"conversation","messageTimestamp":1741276800}}'

# Testes unitários (Python 3.11)
pytest tests/unit/test_onboarding_agent.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)